### PR TITLE
Add root __init__.py to enable custom node discovery

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,28 @@
+print("### Loading: Custom Nodes Collection ###")
+
+# Import mappings from AnalogFilmNoiseNode
+try:
+    from .AnalogFilmNoiseNode import NODE_CLASS_MAPPINGS as AnalogFilmNoise_class_mappings, NODE_DISPLAY_NAME_MAPPINGS as AnalogFilmNoise_display_mappings
+except ImportError:
+    print("[WARN] AnalogFilmNoiseNode not found. Skipping.")
+    AnalogFilmNoise_class_mappings = {}
+    AnalogFilmNoise_display_mappings = {}
+
+# Import mappings from ClearGpuMemoryCacheNode
+try:
+    from .ClearGpuMemoryCacheNode import NODE_CLASS_MAPPINGS as ClearGpuMemoryCache_class_mappings, NODE_DISPLAY_NAME_MAPPINGS as ClearGpuMemoryCache_display_mappings
+except ImportError:
+    print("[WARN] ClearGpuMemoryCacheNode not found. Skipping.")
+    ClearGpuMemoryCache_class_mappings = {}
+    ClearGpuMemoryCache_display_mappings = {}
+
+# Aggregate mappings
+NODE_CLASS_MAPPINGS = {}
+NODE_CLASS_MAPPINGS.update(AnalogFilmNoise_class_mappings)
+NODE_CLASS_MAPPINGS.update(ClearGpuMemoryCache_class_mappings)
+
+NODE_DISPLAY_NAME_MAPPINGS = {}
+NODE_DISPLAY_NAME_MAPPINGS.update(AnalogFilmNoise_display_mappings)
+NODE_DISPLAY_NAME_MAPPINGS.update(ClearGpuMemoryCache_display_mappings)
+
+__all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS']


### PR DESCRIPTION
This commit introduces a root-level __init__.py file. This file is essential for ComfyUI to discover and load custom nodes located in subdirectories.

The __init__.py imports NODE_CLASS_MAPPINGS and
NODE_DISPLAY_NAME_MAPPINGS from:
- AnalogFilmNoiseNode
- ClearGpuMemoryCacheNode

It then aggregates these mappings and exports them, allowing ComfyUI to register all included custom nodes. Error handling for imports has been added to prevent issues if a node directory is missing.