### PR TITLE
chore: Harden workflow — gitignore .claude/, enforce branch-first and test gate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
-__pycache__
+__pycache__/
+*.pyc
+.claude/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,25 +80,41 @@ import { app } from "../../scripts/app.js";
 app.registerExtension({ name: "comfynodes.<extension_name>", ... });
 ```
 
-## Before Committing
+## Before Starting Any Work
 
-Always make sure commit is not done on main branch. Create branch if needed.
+**Step 0 — always create a feature branch first. Never work on main.**
+
+```bash
+git checkout -b <branch-name>
+```
+
+Check you are not on main:
+
+```bash
+git branch --show-current   # must NOT be "main"
+```
+
+## Before Committing
 
 ```bash
 uv run black nodes.py
 ```
 
 Install black if needed:
+
 ```bash
 uv pip install black
 ```
 
 ## Testing a Node
 
+Do this **before committing** any new or changed node — do not skip:
+
 1. Restart ComfyUI (or use the Manager's "Reload Custom Nodes" if available)
 2. Open browser DevTools console — check for JS errors on load
 3. Search for the node by display name in the ComfyUI node menu
 4. Connect inputs, run the workflow, check the ComfyUI terminal for Python errors
+5. Confirm the node produces correct output before committing
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary

- Add `.claude/`, `*.pyc`, `__pycache__/` to `.gitignore` (prevents local tooling config from being committed)
- Add **Before Starting Any Work** section to `CLAUDE.md` with an explicit branch check as step 0 — branch must be created before touching any files
- Strengthen **Testing a Node** section with a mandatory pre-commit gate

## Why

These changes address two recurring workflow failures observed in this session:
1. `.claude/settings.local.json` was accidentally committed — now gitignored
2. All commits went directly to main despite the rule existing — step 0 makes the branch check impossible to miss

🤖 Generated with [Claude Code](https://claude.com/claude-code)